### PR TITLE
Meta Audience Network - Expose statically configurable fields

### DIFF
--- a/MetaAudienceNetworkAdapter/src/main/java/com/chartboost/helium/metaaudiencenetworkadapter/MetaAudienceNetworkAdapter.kt
+++ b/MetaAudienceNetworkAdapter/src/main/java/com/chartboost/helium/metaaudiencenetworkadapter/MetaAudienceNetworkAdapter.kt
@@ -42,16 +42,11 @@ class MetaAudienceNetworkAdapter : PartnerAdapter {
         public var placementIds = listOf<String>()
             set(value) {
                 field = value
-                if (value.isNotEmpty()) {
-                    LogController.d(
-                        "$TAG - Meta Audience Network placement IDs provided for initialization: " +
-                                value.joinToString()
-                    )
-                } else {
-                    LogController.d(
-                        "$TAG - Meta Audience Network placement IDs not provided for initialization."
-                    )
-                }
+                LogController.d(
+                    "Meta Audience Network placement IDs " +
+                            if (value.isEmpty()) "not provided for initialization."
+                            else "provided for initialization: ${value.joinToString()}."
+                )
             }
 
         /**


### PR DESCRIPTION
Talking to Kelly it seemed like this is a nice use case to support—basically exposing "essential" fields so publishers can configure them from their apps. At MoPub this was the "AdapterConfiguration" implementation.

Here's a sample implementation. LMK what you think. There isn't going to be a lot of fields—most notably there'll be a test mode flag alongside something else. 

Pubs can set them from the apps like so:

```kt
MetaAudienceNetworkAdapter.testMode = true
MetaAudienceNetworkAdapter.placementIds = listOf("ABC", "DEF", "GHI")
```

If this format looks good we can replicate it to the other adapters. 