### PR TITLE
fix(build): pin androidx.browser to 1.8.0 for AGP 8.2.2 / API 34 compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,6 +18,21 @@ plugins {
     id("org.jetbrains.kotlin.android") version "1.9.21" apply false
 }
 
+allprojects {
+    // The Facebook Audience Network SDK transitively resolves androidx.browser
+    // up to 1.9.0, whose AAR metadata declares minCompileSdk=36 and
+    // minAgpVersion=8.9.1. That trips checkRemoteReleaseAarMetadata during
+    // assembleRemote / release while this adapter compiles against API 34 on
+    // AGP 8.2.2. 1.8.0 is the latest release compatible with API 34 and our
+    // current AGP; the Custom Tabs API surface is unchanged between 1.8.0 and
+    // 1.9.0. Remove once this repo moves to compileSdk 36 + AGP 8.9.1+.
+    configurations.all {
+        resolutionStrategy {
+            force("androidx.browser:browser:1.8.0")
+        }
+    }
+}
+
 task<Delete>("clean") {
     delete(rootProject.buildDir)
 }


### PR DESCRIPTION
## What
Force `androidx.browser:browser:1.8.0` across all projects in the root `build.gradle.kts`.

## Why
The Facebook Audience Network SDK transitively resolves `androidx.browser` up to **1.9.0**, whose AAR metadata declares **minCompileSdk=36** and **minAgpVersion=8.9.1**. This adapter compiles against **API 34** on **AGP 8.2.2**, so `checkRemoteReleaseAarMetadata` fails during `assembleRemote` / release (this is what broke the helium-android nightly on the equivalent module).

`1.8.0` is the latest `androidx.browser` release compatible with API 34 and our current AGP. The Custom Tabs API surface is unchanged between 1.8.0 and 1.9.0.

## Follow-up
Remove this force once the repo moves to compileSdk 36 + AGP 8.9.1+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)